### PR TITLE
Add WebGPU WebAssembly example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "webgpu_wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wgpu = { version = "0.17", features = ["webgpu"] }
+console_error_panic_hook = "0.1"
+web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# rust
+# WebGPU in Rust via WebAssembly
+
+This repository contains a minimal example of using WebGPU from Rust
+compiled to WebAssembly. The example clears a canvas with a color
+inside the browser.
+
+## Building
+
+Install the WebAssembly target for Rust and build with `wasm-pack`:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack    # if not already installed
+wasm-pack build --target web
+```
+
+This will create a `pkg/` directory with the generated JavaScript and
+WebAssembly files.
+
+## Running
+
+Serve the `index.html` file with any static web server so that the
+browser can load the WebAssembly module.
+
+```bash
+python3 -m http.server
+```
+
+Then open `http://localhost:8000` in a browser with WebGPU enabled.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>WebGPU with Rust/WASM</title>
+</head>
+<body>
+    <canvas id="gpu-canvas" width="640" height="480"></canvas>
+    <script type="module">
+        import init from './pkg/webgpu_wasm.js';
+        init();
+    </script>
+</body>
+</html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,80 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+#[wasm_bindgen(start)]
+pub async fn start() -> Result<(), JsValue> {
+    console_error_panic_hook::set_once();
+
+    // Access the canvas element from the document
+    let window = web_sys::window().expect("no global `window` exists");
+    let document = window.document().expect("should have a document on window");
+    let canvas = document
+        .get_element_by_id("gpu-canvas")
+        .expect("Canvas with id 'gpu-canvas' not found")
+        .dyn_into::<web_sys::HtmlCanvasElement>()?;
+
+    // Initialize wgpu
+    let instance = wgpu::Instance::default();
+    let surface = unsafe { instance.create_surface_from_canvas(&canvas) }?;
+
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        })
+        .await
+        .ok_or("failed to find an appropriate adapter")?;
+
+    let (device, queue) = adapter
+        .request_device(&wgpu::DeviceDescriptor::default(), None)
+        .await?;
+
+    let config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format: surface.get_supported_formats(&adapter)[0],
+        width: canvas.width(),
+        height: canvas.height(),
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+        view_formats: vec![],
+    };
+    surface.configure(&device, &config);
+
+    let frame = surface
+        .get_current_texture()
+        .expect("Failed to acquire next surface texture");
+    let view = frame
+        .texture
+        .create_view(&wgpu::TextureViewDescriptor::default());
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("render encoder"),
+    });
+
+    {
+        let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("render pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: 0.1,
+                        g: 0.2,
+                        b: 0.3,
+                        a: 1.0,
+                    }),
+                    store: true,
+                },
+            })],
+            depth_stencil_attachment: None,
+        });
+    }
+
+    queue.submit(std::iter::once(encoder.finish()));
+    frame.present();
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add Cargo manifest for a `cdylib` crate targeting WebAssembly
- create minimal `src/lib.rs` that clears a canvas using WebGPU
- include `index.html` to load the generated WASM in the browser
- document build and run steps in README

## Testing
- `cargo check` *(fails: Could not connect to server)*