### PR TITLE
Fix build instructions in README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-wgpu = { version = "0.17", features = ["webgpu"] }
+wgpu = { version = "0.17", default-features = false, features = ["webgpu"] }
 console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Install the WebAssembly target for Rust and build with `wasm-pack`:
 
 ```bash
 rustup target add wasm32-unknown-unknown
-cargo install wasm-pack    # if not already installed
+
+# Install `wasm-pack` if it is not already available
+cargo install wasm-pack
+
 wasm-pack build --target web
 ```
 


### PR DESCRIPTION
## Summary
- clarify how to install `wasm-pack` in README so the comment isn't mistaken for a crate name
- disable `wgpu` default features so the WebGPU backend builds correctly

## Testing
- `cargo check` *(fails: failed to download crates)*
