### PR TITLE
Fix README instructions and wgpu feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-wgpu = { version = "0.17", default-features = false, features = ["webgpu"] }
+wgpu = "0.17"
 console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Install the WebAssembly target for Rust and build with `wasm-pack`:
 ```bash
 rustup target add wasm32-unknown-unknown
 
-# Install `wasm-pack` if it is not already available
+# Install `wasm-pack` if it is not already available.
+# (Do **not** include this comment after the command.)
 cargo install wasm-pack
 
 wasm-pack build --target web


### PR DESCRIPTION
## Summary
- clarify `wasm-pack` installation instructions in README
- remove nonexistent `webgpu` feature from `wgpu`

## Testing
- `cargo check --target wasm32-unknown-unknown` *(fails: could not download crates)*