### PR TITLE
Fix wgpu dependency for wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-wgpu = { version = "0.17", features = ["webgpu"] }
+wgpu = "0.17"
 console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ inside the browser.
 
 Install the WebAssembly target for Rust and build with `wasm-pack`.
 The WebGPU API in `web-sys` is still unstable, so compilation requires
-enabling those APIs via `RUSTFLAGS`. The `wgpu` crate also needs the
-`webgpu` feature enabled (already set in `Cargo.toml`).
+enabling those APIs via `RUSTFLAGS`.
 
 ```bash
 rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
## Summary
- remove the non-existent `webgpu` feature from `wgpu` dependency
- update README instructions accordingly

## Testing
- `cargo check` *(fails: failed to download crates)*