### PR TITLE
Offline vendor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,35 +36,42 @@ Then open `http://localhost:8000` in a browser with WebGPU enabled.
 
 ## Offline usage
 
-If you need to work in an environment without internet access, vendor all
-dependencies and prepare WebAssembly artifacts ahead of time.
+This repository ships the file `vendor.tar.zst` containing all required
+crates so that builds can happen without network connectivity.  Run the
+provided `./evendor` script to unpack the archive and prepare the `vendor/`
+directory before building:
 
-1. Vendor the crates and configure Cargo to use them:
+```bash
+./evendor
+```
+
+The script also synchronizes Cargo's metadata with the extracted crates. If
+you later change dependencies you can refresh the vendor directory using:
 
 ```bash
 cargo vendor --sync ./vendor
 ```
 
-Create `.cargo/config.toml` with:
+Cargo is configured in `.cargo/config.toml` to use these local sources:
 
 ```toml
 [source.crates-io]
-replace-with = "vendored"
+replace-with = "vendored-sources"
 
-[source.vendored]
+[source.vendored-sources]
 directory = "vendor"
 ```
 
-2. Build and test completely offline:
+After unpacking the vendor directory you can build and test completely
+offline:
 
 ```bash
 cargo test --offline
 cargo build --target wasm32-unknown-unknown --release --offline
 ```
 
-3. Run `wasm-bindgen` before entering the offline sandbox and copy the
-   resulting files along with any required runners (for example `node` or
-   `wasmtime`):
+Run `wasm-bindgen` before entering the offline sandbox and copy the resulting
+files along with any required runners (for example `node` or `wasmtime`):
 
 ```bash
 wasm-bindgen --target web --out-dir wasm_out \

--- a/evendor
+++ b/evendor
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Extract vendored crates from the archived vendor.tar.zst file
+# Requires `zstd` to be installed.
+
+# Skip extraction if vendor directory already exists
+if [ -d "vendor" ]; then
+  echo "vendor directory already exists"
+  exit 0
+fi
+
+# Decompress the archive and extract it
+zstd -d vendor.tar.zst -c | tar -xv
+
+# Synchronize Cargo's metadata with the vendor directory
+cargo vendor --sync ./vendor >/dev/null
+
+echo "Vendor directory prepared"


### PR DESCRIPTION
## Summary
- document how to prepare the vendored crates for offline builds
- add `evendor` helper script for unpacking `vendor.tar.zst`

## Testing
- `./evendor` *(fails: zstd not installed)*
- `cargo test --offline` *(fails: missing vendor directory)*