### PR TITLE
Fix offline vendor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository ships the file `vendor.tar.zst` containing all required
 crates so that builds can happen without network connectivity.  Run the
 provided `./evendor` script to unpack the archive and prepare the `vendor/`
 directory before building. The script relies on the `zstd` tool to
-
+decompress the archive, so make sure it is installed:
 
 ```bash
 ./evendor


### PR DESCRIPTION
## Summary
- fix missing sentence about installing `zstd` in the README

## Testing
- `cargo build` *(fails: failed to get `console_error_panic_hook`)*