### PR TITLE
Fix WebGPU initialization for web

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ decompress the archive, so make sure it is installed:
 ./evendor
 ```
 
+If `zstd` is not available you can repackage the vendor directory as
+`vendor.tar.gz` or `vendor.zip` on another machine and extract that
+instead. After extracting, run `cargo vendor --sync ./vendor` once to
+update Cargo's metadata:
+
+```bash
+# On a machine with `zstd` available
+tar -I zstd -xf vendor.tar.zst
+tar -czf vendor.tar.gz vendor  # or: zip -r vendor.zip vendor
+
+# On the target system without `zstd`
+tar -xzf vendor.tar.gz         # or: unzip vendor.zip
+cargo vendor --sync ./vendor
+```
+
 The script is idempotent: if a `vendor/` directory already exists it will skip
 the extraction step so previously downloaded crates are reused.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub async fn start() -> Result<(), JsValue> {
 
     // Initialize wgpu
     let instance = wgpu::Instance::default();
-    let surface = unsafe { instance.create_surface_from_canvas(&canvas) }?;
+    let surface = unsafe { instance.create_surface(&canvas) }?;
 
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
@@ -28,7 +28,8 @@ pub async fn start() -> Result<(), JsValue> {
 
     let (device, queue) = adapter
         .request_device(&wgpu::DeviceDescriptor::default(), None)
-        .await?;
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,


### PR DESCRIPTION
## Summary
- use `create_surface` to initialize the WebGPU surface
- convert `RequestDeviceError` into a `JsValue`
- document alternative extraction steps for the vendored crates

## Testing
- `cargo test --offline` *(fails: failed to read root of directory source: /workspace/rust/vendor)*
- `cargo build --target wasm32-unknown-unknown --release --offline` *(fails: failed to read root of directory source: /workspace/rust/vendor)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.