### PR TITLE
Oprava offline buildu

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ cargo test --offline
 cargo build --target wasm32-unknown-unknown --release --offline
 ```
 
+Ensure that the `wasm32-unknown-unknown` target is installed **before**
+going offline.  If it is missing the build will fail with an error like
+`can't find crate for 'core'`.  Install it while online via:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
 Run `wasm-bindgen` before entering the offline sandbox and copy the resulting
 files along with any required runners (for example `node` or `wasmtime`):
 

--- a/evendor
+++ b/evendor
@@ -8,6 +8,13 @@ if [ -d "vendor" ]; then
   exit 0
 fi
 
+# Warn if the WebAssembly target is not installed. Building will fail
+# offline without it.
+if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
+  echo "warning: target 'wasm32-unknown-unknown' not installed." >&2
+  echo "         run 'rustup target add wasm32-unknown-unknown' while online" >&2
+fi
+
 
 # Extract vendored crates from vendor.tar.gz
 tar -xzvf vendor.tar.gz


### PR DESCRIPTION
## Notes
- README nyní zdůrazňuje nutnost mít dopředu nainstalovaný target `wasm32-unknown-unknown`.
- Skript `evendor` nyní před rozbalením zkontroluje, že je daný target nainstalován, a případně vypíše varování.

## Testing
- `cargo build --offline`
- `cargo test --offline`
