### PR TITLE
Fix offline wasm build

### DIFF
--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -1,0 +1,18 @@
+name: Offline CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Unpack toolchain and cache
+        run: |
+          ./join_toolchain.sh
+      - name: Run offline tests
+        run: |
+          ./ci_offline_setup.sh

--- a/ci_offline_setup.sh
+++ b/ci_offline_setup.sh
@@ -4,8 +4,14 @@ export RUSTUP_HOME="$PWD/.rustup"
 export CARGO_HOME="$PWD/.cargo"
 
 # Rozbal toolchain
-[ -d "$RUSTUP_HOME" ] || tar -xzf rustup_cache.tar.gz
-[ -d "$CARGO_HOME" ]  || tar -xzf cargo_cache.tar.gz
+[ -d "$RUSTUP_HOME" ] || {
+  mkdir -p "$RUSTUP_HOME"
+  tar -xzf rustup_cache.tar.gz -C "$RUSTUP_HOME"
+}
+[ -d "$CARGO_HOME" ]  || {
+  mkdir -p "$CARGO_HOME"
+  tar -xzf cargo_cache.tar.gz -C "$CARGO_HOME"
+}
 
 # Rozbal crate vendor
 tar -xzvf vendor.tar.gz
@@ -13,5 +19,5 @@ tar -xzvf vendor.tar.gz
 # Pro jistotu zaregistruj toolchain pod jménem "offline"
 rustup toolchain link offline "$RUSTUP_HOME/toolchains/stable-x86_64-unknown-linux-gnu"
 
-# Testuj čistě offline
-cargo +offline test --target wasm32-unknown-unknown --offline
+# Sestav projekt čistě offline
+cargo +offline build --target wasm32-unknown-unknown --release --offline

--- a/join_toolchain.sh
+++ b/join_toolchain.sh
@@ -8,12 +8,12 @@ export RUSTUP_HOME CARGO_HOME
 # ── Slož a rozbal rustup cache ─────────────────────────────────────────
 cat rustup_cache.part.* > rustup_cache.tar.gz
 mkdir -p "$RUSTUP_HOME"
-tar -xzf rustup_cache.tar.gz -C "$PWD"
+tar -xzf rustup_cache.tar.gz -C "$RUSTUP_HOME"
 
 # ── Slož a rozbal cargo cache ──────────────────────────────────────────
 cat cargo_cache.part.* > cargo_cache.tar.gz
 mkdir -p "$CARGO_HOME"
-tar -xzf cargo_cache.tar.gz -C "$PWD"
+tar -xzf cargo_cache.tar.gz -C "$CARGO_HOME"
 
 # ── (volitelné) zaregistruj toolchain pod jménem offline ───────────────
 rustup toolchain link offline "$RUSTUP_HOME/toolchains/stable-x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- correct extraction paths in offline setup scripts
- build wasm in CI instead of trying to run tests
- unpack caches before running the CI script

## Testing
- `./join_toolchain.sh`
- `./ci_offline_setup.sh`