### PR TITLE
fix limit compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,18 @@
 <body>
     <canvas id="gpu-canvas" width="640" height="480"></canvas>
     <script type="module">
+        // Patch outdated WebGPU limit name for newer Chrome versions.
+        const origRequestDevice = GPUAdapter.prototype.requestDevice;
+        GPUAdapter.prototype.requestDevice = function(desc) {
+            if (desc?.requiredLimits?.maxInterStageShaderComponents !== undefined &&
+                desc.requiredLimits.maxInterStageShaderVariables === undefined) {
+                desc.requiredLimits.maxInterStageShaderVariables =
+                    desc.requiredLimits.maxInterStageShaderComponents;
+                delete desc.requiredLimits.maxInterStageShaderComponents;
+            }
+            return origRequestDevice.call(this, desc);
+        };
+
         import init from './pkg/webgpu_wasm.js';
         init();
     </script>


### PR DESCRIPTION
## Summary
- patch `GPUAdapter.requestDevice` in index.html to handle renamed WebGPU limits

## Testing
- `cargo +offline build --target wasm32-unknown-unknown --release --offline`
