### PR TITLE
fix limit compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,18 @@
 <body>
     <canvas id="gpu-canvas" width="640" height="480"></canvas>
     <script type="module">
+        // Patch outdated WebGPU limit name for newer Chrome versions.
+        const origRequestDevice = GPUAdapter.prototype.requestDevice;
+        GPUAdapter.prototype.requestDevice = function(desc) {
+            if (desc?.requiredLimits?.maxInterStageShaderComponents !== undefined &&
+                desc.requiredLimits.maxInterStageShaderVariables === undefined) {
+                desc.requiredLimits.maxInterStageShaderVariables =
+                    desc.requiredLimits.maxInterStageShaderComponents;
+                delete desc.requiredLimits.maxInterStageShaderComponents;
+            }
+            return origRequestDevice.call(this, desc);
+        };
+
         import init from './pkg/webgpu_wasm.js';
         init();
     </script>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,15 @@ pub async fn start() -> Result<(), JsValue> {
 
     // Po odstranění starého limitu `maxInterStageShaderComponents` musí být
     // vytvoření zařízení explicitní, abychom nepožadovali neznámé limity.
+    // Request only the limits supported by the current adapter to avoid
+    // mismatches on browsers that changed WebGPU limit names.
+    let adapter_limits = adapter.limits();
+
     let (device, queue) = {
         let desc = wgpu::DeviceDescriptor {
             label: None,
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
+            required_limits: adapter_limits,
         };
         adapter
             .request_device(&desc, None)


### PR DESCRIPTION
## Summary
- patch `GPUAdapter.requestDevice` in index.html to handle renamed WebGPU limits
- request supported limits from the adapter to avoid mismatches on creation

## Testing
- `cargo +offline build --target wasm32-unknown-unknown --release --offline`
