### PR TITLE
Rotující krychle ve WebGPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ name = "webgpu_wasm"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ wasm-bindgen-futures = "0.4"
 wgpu = { version = "0.20.1", features = ["webgpu", "wgsl"] }
 console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
+js-sys = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,109 +1,432 @@
 #[cfg(target_arch = "wasm32")]
+use std::{cell::RefCell, rc::Rc};
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{closure::Closure, JsCast};
+#[cfg(target_arch = "wasm32")]
+use wgpu::util::DeviceExt;
+
+mod math;
+#[cfg(target_arch = "wasm32")]
+use crate::math::{look_at, mat4_mul, perspective, rotation_y};
+
+#[cfg(target_arch = "wasm32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Vertex {
+    position: [f32; 3],
+    normal: [f32; 3],
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Vertex {
+    fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+        use std::mem;
+        wgpu::VertexBufferLayout {
+            array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+                wgpu::VertexAttribute {
+                    offset: mem::size_of::<[f32; 3]>() as u64,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+            ],
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+const VERTICES: &[Vertex] = &[
+    // front
+    Vertex {
+        position: [-1.0, -1.0, 1.0],
+        normal: [0.0, 0.0, 1.0],
+    },
+    Vertex {
+        position: [1.0, -1.0, 1.0],
+        normal: [0.0, 0.0, 1.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, 1.0],
+        normal: [0.0, 0.0, 1.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, 1.0],
+        normal: [0.0, 0.0, 1.0],
+    },
+    // back
+    Vertex {
+        position: [1.0, -1.0, -1.0],
+        normal: [0.0, 0.0, -1.0],
+    },
+    Vertex {
+        position: [-1.0, -1.0, -1.0],
+        normal: [0.0, 0.0, -1.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, -1.0],
+        normal: [0.0, 0.0, -1.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, -1.0],
+        normal: [0.0, 0.0, -1.0],
+    },
+    // top
+    Vertex {
+        position: [-1.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, -1.0],
+        normal: [0.0, 1.0, 0.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, -1.0],
+        normal: [0.0, 1.0, 0.0],
+    },
+    // bottom
+    Vertex {
+        position: [-1.0, -1.0, -1.0],
+        normal: [0.0, -1.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, -1.0, -1.0],
+        normal: [0.0, -1.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, -1.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
+    },
+    Vertex {
+        position: [-1.0, -1.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
+    },
+    // right
+    Vertex {
+        position: [1.0, -1.0, 1.0],
+        normal: [1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, -1.0, -1.0],
+        normal: [1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, -1.0],
+        normal: [1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, 1.0],
+        normal: [1.0, 0.0, 0.0],
+    },
+    // left
+    Vertex {
+        position: [-1.0, -1.0, -1.0],
+        normal: [-1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [-1.0, -1.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, -1.0],
+        normal: [-1.0, 0.0, 0.0],
+    },
+];
+
+#[cfg(target_arch = "wasm32")]
+const INDICES: &[u16] = &[
+    0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, 8, 9, 10, 8, 10, 11, 12, 13, 14, 12, 14, 15, 16, 17, 18,
+    16, 18, 19, 20, 21, 22, 20, 22, 23,
+];
+
+#[cfg(target_arch = "wasm32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Uniforms {
+    mvp: [[f32; 4]; 4],
+    model: [[f32; 4]; 4],
+    light_dir: [f32; 4],
+}
+
+#[cfg(target_arch = "wasm32")]
+fn as_bytes<T: Copy>(data: &[T]) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(
+            data.as_ptr() as *const u8,
+            data.len() * std::mem::size_of::<T>(),
+        )
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+struct State {
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    num_indices: u32,
+    uniform_buffer: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    proj_view: [[f32; 4]; 4],
+    start_time: f64,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl State {
+    async fn new(canvas: &web_sys::HtmlCanvasElement) -> Result<Self, JsValue> {
+        let instance = wgpu::Instance::default();
+        let surface = instance
+            .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or("failed to find adapter")?;
+
+        let adapter_limits = adapter.limits();
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    required_features: wgpu::Features::empty(),
+                    required_limits: adapter_limits,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        let caps = surface.get_capabilities(&adapter);
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: caps.formats[0],
+            width: canvas.width(),
+            height: canvas.height(),
+            desired_maximum_frame_latency: 2,
+            present_mode: caps.present_modes[0],
+            alpha_mode: caps.alpha_modes[0],
+            view_formats: vec![],
+        };
+        surface.configure(&device, &config);
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+        });
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("vertex buffer"),
+            contents: as_bytes(VERTICES),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("index buffer"),
+            contents: as_bytes(INDICES),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let uniform = Uniforms {
+            mvp: [[0.0; 4]; 4],
+            model: [[0.0; 4]; 4],
+            light_dir: [0.0, 0.0, -1.0, 0.0],
+        };
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("uniform buffer"),
+            contents: as_bytes(&[uniform]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+            label: Some("bind group"),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("pipeline layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                buffers: &[Vertex::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: config.format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                cull_mode: Some(wgpu::Face::Back),
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        let aspect = config.width as f32 / config.height as f32;
+        let proj = perspective(aspect, 45f32.to_radians(), 0.1, 10.0);
+        let view = look_at([0.0, 0.0, 5.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
+        let proj_view = mat4_mul(proj, view);
+
+        Ok(Self {
+            surface,
+            device,
+            queue,
+            config,
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            num_indices: INDICES.len() as u32,
+            uniform_buffer,
+            bind_group,
+            proj_view,
+            start_time: js_sys::Date::now(),
+        })
+    }
+
+    fn update(&mut self) {
+        let now = js_sys::Date::now();
+        let t = ((now - self.start_time) / 1000.0) as f32;
+        let model = rotation_y(t);
+        let mvp = mat4_mul(self.proj_view, model);
+        let uniform = Uniforms {
+            mvp,
+            model,
+            light_dir: [0.0, 0.0, -1.0, 0.0],
+        };
+        self.queue
+            .write_buffer(&self.uniform_buffer, 0, as_bytes(&[uniform]));
+    }
+
+    fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+        let frame = self.surface.get_current_texture()?;
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("encoder"),
+            });
+        {
+            let mut rp = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("render"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.1,
+                            g: 0.2,
+                            b: 0.3,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+            rp.set_pipeline(&self.pipeline);
+            rp.set_bind_group(0, &self.bind_group, &[]);
+            rp.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            rp.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            rp.draw_indexed(0..self.num_indices, 0, 0..1);
+        }
+        self.queue.submit(std::iter::once(encoder.finish()));
+        frame.present();
+        Ok(())
+    }
+}
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 #[cfg(target_arch = "wasm32")]
 pub async fn start() -> Result<(), JsValue> {
     console_error_panic_hook::set_once();
-
-    // Access the canvas element from the document
-    let window = web_sys::window().expect("no global `window` exists");
-    let document = window.document().expect("should have a document on window");
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
     let canvas = document
         .get_element_by_id("gpu-canvas")
-        .expect("Canvas with id 'gpu-canvas' not found")
+        .unwrap()
         .dyn_into::<web_sys::HtmlCanvasElement>()?;
 
-    // Initialize wgpu
-    let instance = wgpu::Instance::default();
-    let surface = instance
-        .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let state = Rc::new(RefCell::new(State::new(&canvas).await?));
+    let f: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
+    let g = f.clone();
+    let window_c = window.clone();
 
-    let adapter = instance
-        .request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: Some(&surface),
-            force_fallback_adapter: false,
-        })
-        .await
-        .ok_or("failed to find an appropriate adapter")?;
+    *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
+        {
+            let mut st = state.borrow_mut();
+            st.update();
+            if st.render().is_err() {
+                return;
+            }
+        }
+        window_c
+            .request_animation_frame(f.borrow().as_ref().unwrap().as_ref().unchecked_ref())
+            .unwrap();
+    }) as Box<dyn FnMut()>));
 
-    // Po odstranění starého limitu `maxInterStageShaderComponents` musí být
-    // vytvoření zařízení explicitní, abychom nepožadovali neznámé limity.
-    // Request only the limits supported by the current adapter to avoid
-    // mismatches on browsers that changed WebGPU limit names.
-    let adapter_limits = adapter.limits();
-
-    let (device, queue) = {
-        let desc = wgpu::DeviceDescriptor {
-            label: None,
-            required_features: wgpu::Features::empty(),
-            required_limits: adapter_limits,
-        };
-        adapter
-            .request_device(&desc, None)
-            .await
-            .map_err(|e| JsValue::from_str(&e.to_string()))?
-    };
-
-    let caps = surface.get_capabilities(&adapter);
-    let config = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: caps.formats[0],
-        width: canvas.width(),
-        height: canvas.height(),
-        desired_maximum_frame_latency: 2,
-        present_mode: caps.present_modes[0],
-        alpha_mode: caps.alpha_modes[0],
-        view_formats: vec![],
-    };
-    surface.configure(&device, &config);
-
-    let frame = surface
-        .get_current_texture()
-        .expect("Failed to acquire next surface texture");
-    let view = frame
-        .texture
-        .create_view(&wgpu::TextureViewDescriptor::default());
-
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("render encoder"),
-    });
-
-    {
-        let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("render pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &view,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color {
-                        r: 0.1,
-                        g: 0.2,
-                        b: 0.3,
-                        a: 1.0,
-                    }),
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            occlusion_query_set: None,
-            timestamp_writes: None,
-        });
-    }
-
-    queue.submit(std::iter::once(encoder.finish()));
-    frame.present();
-
+    window.request_animation_frame(g.borrow().as_ref().unwrap().as_ref().unchecked_ref())?;
     Ok(())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn start() -> Result<(), ()> {
-    // No-op when not targeting WebAssembly
     Ok(())
 }
-

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,60 @@
+pub fn mat4_mul(a: [[f32; 4]; 4], b: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
+    let mut r = [[0.0; 4]; 4];
+    for i in 0..4 {
+        for j in 0..4 {
+            r[i][j] = a[i][0] * b[0][j] + a[i][1] * b[1][j] + a[i][2] * b[2][j] + a[i][3] * b[3][j];
+        }
+    }
+    r
+}
+
+pub fn rotation_y(angle: f32) -> [[f32; 4]; 4] {
+    let c = angle.cos();
+    let s = angle.sin();
+    [
+        [c, 0.0, s, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [-s, 0.0, c, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+}
+
+fn normalize(v: [f32; 3]) -> [f32; 3] {
+    let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    [v[0] / l, v[1] / l, v[2] / l]
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+pub fn look_at(eye: [f32; 3], center: [f32; 3], up: [f32; 3]) -> [[f32; 4]; 4] {
+    let f = normalize([center[0] - eye[0], center[1] - eye[1], center[2] - eye[2]]);
+    let s = normalize(cross(f, up));
+    let u = cross(s, f);
+    [
+        [s[0], u[0], -f[0], 0.0],
+        [s[1], u[1], -f[1], 0.0],
+        [s[2], u[2], -f[2], 0.0],
+        [-dot(s, eye), -dot(u, eye), dot(f, eye), 1.0],
+    ]
+}
+
+pub fn perspective(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 4] {
+    let f = 1.0 / (fovy / 2.0).tan();
+    let nf = 1.0 / (znear - zfar);
+    [
+        [f / aspect, 0.0, 0.0, 0.0],
+        [0.0, f, 0.0, 0.0],
+        [0.0, 0.0, (zfar + znear) * nf, -1.0],
+        [0.0, 0.0, (2.0 * zfar * znear) * nf, 0.0],
+    ]
+}

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,0 +1,38 @@
+struct Uniforms {
+    mvp : mat4x4<f32>;
+    model: mat4x4<f32>;
+    light_dir: vec4<f32>;
+};
+
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>;
+    @location(1) normal: vec3<f32>;
+};
+
+struct VertexOutput {
+    @builtin(position) pos: vec4<f32>;
+    @location(0) normal: vec3<f32>;
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.pos = uniforms.mvp * vec4<f32>(input.position, 1.0);
+    out.normal = (uniforms.model * vec4<f32>(input.normal, 0.0)).xyz;
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let light = normalize(uniforms.light_dir.xyz);
+    let n = normalize(input.normal);
+    let diffuse = max(dot(n, light), 0.0);
+    let view_dir = vec3<f32>(0.0, 0.0, 1.0);
+    let reflect_dir = reflect(-light, n);
+    let spec = pow(max(dot(view_dir, reflect_dir), 0.0), 16.0);
+    let ambient = 0.3;
+    let color = vec3<f32>(0.4, 0.6, 0.8) * (ambient + diffuse) + vec3<f32>(1.0) * spec;
+    return vec4<f32>(color, 1.0);
+}


### PR DESCRIPTION
## Shrnutí
- přidán modul s jednoduchou linear algebra pro matice
- implementován render rotující krychle s Phongovým stínováním
- přidán shader ve WGSL
- doplněna závislost `js-sys`

## Testování
- `cargo +offline test --target wasm32-unknown-unknown --no-run --offline`
