### PR TITLE
Fix perspective matrix for WebGPU

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -54,7 +54,7 @@ pub fn perspective(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 
     [
         [f / aspect, 0.0, 0.0, 0.0],
         [0.0, f, 0.0, 0.0],
-        [0.0, 0.0, (zfar + znear) * nf, -1.0],
-        [0.0, 0.0, (2.0 * zfar * znear) * nf, 0.0],
+        [0.0, 0.0, zfar * nf, -1.0],
+        [0.0, 0.0, znear * zfar * nf, 0.0],
     ]
 }


### PR DESCRIPTION
## Summary
- adjust math::perspective to produce coordinates for WebGPU (0..1 NDC)

## Testing
- `cargo test` *(fails: could not download Rust toolchain)*