### PR TITLE
Jednoduchý zelený trojúhelník

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,13 @@
 <head>
     <meta charset="UTF-8" />
     <title>WebGPU with Rust/WASM</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        #camera, #gpu-canvas { position: absolute; top: 0; left: 0; }
+    </style>
 </head>
 <body>
+    <video id="camera" width="640" height="480" autoplay playsinline></video>
     <canvas id="gpu-canvas" width="640" height="480"></canvas>
     <script type="module">
         // Patch outdated WebGPU limit name for newer Chrome versions.
@@ -18,6 +23,11 @@
             }
             return origRequestDevice.call(this, desc);
         };
+
+        navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+            const video = document.getElementById('camera');
+            video.srcObject = stream;
+        }).catch(console.error);
 
         import init from './pkg/webgpu_wasm.js';
         init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,11 @@ use wasm_bindgen::{closure::Closure, JsCast};
 #[cfg(target_arch = "wasm32")]
 use wgpu::util::DeviceExt;
 
-mod math;
-#[cfg(target_arch = "wasm32")]
-use crate::math::{look_at, mat4_mul, perspective, rotation_y};
-
 #[cfg(target_arch = "wasm32")]
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct Vertex {
-    position: [f32; 3],
-    normal: [f32; 3],
+    position: [f32; 2],
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -26,151 +21,25 @@ impl Vertex {
         wgpu::VertexBufferLayout {
             array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    offset: 0,
-                    shader_location: 0,
-                    format: wgpu::VertexFormat::Float32x3,
-                },
-                wgpu::VertexAttribute {
-                    offset: mem::size_of::<[f32; 3]>() as u64,
-                    shader_location: 1,
-                    format: wgpu::VertexFormat::Float32x3,
-                },
-            ],
+            attributes: &[wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x2,
+            }],
         }
     }
 }
 
 #[cfg(target_arch = "wasm32")]
 const VERTICES: &[Vertex] = &[
-    // front
-    Vertex {
-        position: [-1.0, -1.0, 1.0],
-        normal: [0.0, 0.0, 1.0],
-    },
-    Vertex {
-        position: [1.0, -1.0, 1.0],
-        normal: [0.0, 0.0, 1.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, 1.0],
-        normal: [0.0, 0.0, 1.0],
-    },
-    Vertex {
-        position: [-1.0, 1.0, 1.0],
-        normal: [0.0, 0.0, 1.0],
-    },
-    // back
-    Vertex {
-        position: [1.0, -1.0, -1.0],
-        normal: [0.0, 0.0, -1.0],
-    },
-    Vertex {
-        position: [-1.0, -1.0, -1.0],
-        normal: [0.0, 0.0, -1.0],
-    },
-    Vertex {
-        position: [-1.0, 1.0, -1.0],
-        normal: [0.0, 0.0, -1.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, -1.0],
-        normal: [0.0, 0.0, -1.0],
-    },
-    // top
-    Vertex {
-        position: [-1.0, 1.0, 1.0],
-        normal: [0.0, 1.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, 1.0],
-        normal: [0.0, 1.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, -1.0],
-        normal: [0.0, 1.0, 0.0],
-    },
-    Vertex {
-        position: [-1.0, 1.0, -1.0],
-        normal: [0.0, 1.0, 0.0],
-    },
-    // bottom
-    Vertex {
-        position: [-1.0, -1.0, -1.0],
-        normal: [0.0, -1.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, -1.0, -1.0],
-        normal: [0.0, -1.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, -1.0, 1.0],
-        normal: [0.0, -1.0, 0.0],
-    },
-    Vertex {
-        position: [-1.0, -1.0, 1.0],
-        normal: [0.0, -1.0, 0.0],
-    },
-    // right
-    Vertex {
-        position: [1.0, -1.0, 1.0],
-        normal: [1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, -1.0, -1.0],
-        normal: [1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, -1.0],
-        normal: [1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, 1.0],
-        normal: [1.0, 0.0, 0.0],
-    },
-    // left
-    Vertex {
-        position: [-1.0, -1.0, -1.0],
-        normal: [-1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [-1.0, -1.0, 1.0],
-        normal: [-1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [-1.0, 1.0, 1.0],
-        normal: [-1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [-1.0, 1.0, -1.0],
-        normal: [-1.0, 0.0, 0.0],
-    },
+    Vertex { position: [-0.5, -0.5] },
+    Vertex { position: [0.5, -0.5] },
+    Vertex { position: [0.0, 0.5] },
 ];
-
-#[cfg(target_arch = "wasm32")]
-const INDICES: &[u16] = &[
-    0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, 8, 9, 10, 8, 10, 11, 12, 13, 14, 12, 14, 15, 16, 17, 18,
-    16, 18, 19, 20, 21, 22, 20, 22, 23,
-];
-
-#[cfg(target_arch = "wasm32")]
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct Uniforms {
-    mvp: [[f32; 4]; 4],
-    model: [[f32; 4]; 4],
-    light_dir: [f32; 4],
-}
 
 #[cfg(target_arch = "wasm32")]
 fn as_bytes<T: Copy>(data: &[T]) -> &[u8] {
-    unsafe {
-        std::slice::from_raw_parts(
-            data.as_ptr() as *const u8,
-            data.len() * std::mem::size_of::<T>(),
-        )
-    }
+    unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * std::mem::size_of::<T>()) }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -180,12 +49,6 @@ struct State {
     queue: wgpu::Queue,
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
-    index_buffer: wgpu::Buffer,
-    num_indices: u32,
-    uniform_buffer: wgpu::Buffer,
-    bind_group: wgpu::BindGroup,
-    proj_view: [[f32; 4]; 4],
-    start_time: f64,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -203,86 +66,41 @@ impl State {
             })
             .await
             .ok_or("failed to find adapter")?;
-
-        let adapter_limits = adapter.limits();
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
                     label: None,
                     required_features: wgpu::Features::empty(),
-                    required_limits: adapter_limits,
+                    required_limits: adapter.limits(),
                 },
                 None,
             )
             .await
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
-
         let caps = surface.get_capabilities(&adapter);
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: caps.formats[0],
             width: canvas.width(),
             height: canvas.height(),
-            desired_maximum_frame_latency: 2,
             present_mode: caps.present_modes[0],
+            desired_maximum_frame_latency: 2,
             alpha_mode: caps.alpha_modes[0],
             view_formats: vec![],
         };
         surface.configure(&device, &config);
 
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
-        });
+        let shader = device.create_shader_module(wgpu::include_wgsl!("shader.wgsl"));
 
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("vertex buffer"),
             contents: as_bytes(VERTICES),
             usage: wgpu::BufferUsages::VERTEX,
         });
-        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("index buffer"),
-            contents: as_bytes(INDICES),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-
-        let uniform = Uniforms {
-            mvp: [[0.0; 4]; 4],
-            model: [[0.0; 4]; 4],
-            light_dir: [0.0, 0.0, -1.0, 0.0],
-        };
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("uniform buffer"),
-            contents: as_bytes(&[uniform]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("bind group layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-        });
-
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("bind group"),
-        });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("pipeline layout"),
-            bind_group_layouts: &[&bind_group_layout],
+            bind_group_layouts: &[],
             push_constant_ranges: &[],
         });
 
@@ -307,7 +125,6 @@ impl State {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
-                cull_mode: Some(wgpu::Face::Back),
                 ..Default::default()
             },
             depth_stencil: None,
@@ -315,51 +132,15 @@ impl State {
             multiview: None,
         });
 
-        let aspect = config.width as f32 / config.height as f32;
-        let proj = perspective(aspect, 45f32.to_radians(), 0.1, 10.0);
-        // Move the camera slightly so the cube is clearly visible
-        let view = look_at([3.0, 2.0, 5.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
-        let proj_view = mat4_mul(proj, view);
-
-        Ok(Self {
-            surface,
-            device,
-            queue,
-            pipeline,
-            vertex_buffer,
-            index_buffer,
-            num_indices: INDICES.len() as u32,
-            uniform_buffer,
-            bind_group,
-            proj_view,
-            start_time: js_sys::Date::now(),
-        })
-    }
-
-    fn update(&mut self) {
-        let now = js_sys::Date::now();
-        let t = ((now - self.start_time) / 1000.0) as f32;
-        let model = rotation_y(t);
-        let mvp = mat4_mul(self.proj_view, model);
-        let uniform = Uniforms {
-            mvp,
-            model,
-            light_dir: [0.0, 0.0, -1.0, 0.0],
-        };
-        self.queue
-            .write_buffer(&self.uniform_buffer, 0, as_bytes(&[uniform]));
+        Ok(Self { surface, device, queue, pipeline, vertex_buffer })
     }
 
     fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
         let frame = self.surface.get_current_texture()?;
-        let view = frame
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("encoder"),
-            });
+        let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("encoder"),
+        });
         {
             let mut rp = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("render"),
@@ -367,13 +148,8 @@ impl State {
                     view: &view,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color {
-                            r: 0.1,
-                            g: 0.2,
-                            b: 0.3,
-                            a: 1.0,
-                        }),
-                        store: wgpu::StoreOp::Store,
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: true,
                     },
                 })],
                 depth_stencil_attachment: None,
@@ -381,12 +157,10 @@ impl State {
                 timestamp_writes: None,
             });
             rp.set_pipeline(&self.pipeline);
-            rp.set_bind_group(0, &self.bind_group, &[]);
             rp.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-            rp.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-            rp.draw_indexed(0..self.num_indices, 0, 0..1);
+            rp.draw(0..3, 0..1);
         }
-        self.queue.submit(std::iter::once(encoder.finish()));
+        self.queue.submit(Some(encoder.finish()));
         frame.present();
         Ok(())
     }
@@ -411,7 +185,6 @@ pub async fn start() -> Result<(), JsValue> {
     *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
         {
             let mut st = state.borrow_mut();
-            st.update();
             if st.render().is_err() {
                 return;
             }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,40 +1,19 @@
-struct Uniforms {
-    mvp : mat4x4<f32>,
-    model: mat4x4<f32>,
-    light_dir: vec4<f32>,
-}
-
-
-@group(0) @binding(0) var<uniform> uniforms : Uniforms;
-
 struct VertexInput {
-    @location(0) position: vec3<f32>,
-    @location(1) normal: vec3<f32>,
-}
+    @location(0) position: vec2<f32>,
+};
 
 struct VertexOutput {
     @builtin(position) pos: vec4<f32>,
-    @location(0) normal: vec3<f32>,
-}
-
+};
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.pos = uniforms.mvp * vec4<f32>(input.position, 1.0);
-    out.normal = (uniforms.model * vec4<f32>(input.normal, 0.0)).xyz;
+    out.pos = vec4<f32>(input.position, 0.0, 1.0);
     return out;
 }
 
 @fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    let light = normalize(uniforms.light_dir.xyz);
-    let n = normalize(input.normal);
-    let diffuse = max(dot(n, light), 0.0);
-    let view_dir = vec3<f32>(0.0, 0.0, 1.0);
-    let reflect_dir = reflect(-light, n);
-    let spec = pow(max(dot(view_dir, reflect_dir), 0.0), 16.0);
-    let ambient = 0.3;
-    let color = vec3<f32>(0.4, 0.6, 0.8) * (ambient + diffuse) + vec3<f32>(1.0) * spec;
-    return vec4<f32>(color, 1.0);
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 1.0, 0.0, 1.0);
 }


### PR DESCRIPTION
## Shrnutí
- velké zjednodušení `src/lib.rs` – nově se renderuje jen trojúhelník
- shader nastavuje konstantní zelenou barvu
- `index.html` nyní načítá kameru a překresluje trojúhelník nad videem

## Testování
- `cargo build` pro wasm selže, protože chybí target `wasm32-unknown-unknown`
