### PR TITLE
Disable webcam request and log message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ wasm-bindgen-futures = "0.4"
 # z 0.17 -> 0.18  (nejmenší API změny; když zvládneš, klidně 0.20.1)
 wgpu = { version = "0.20.1", features = ["webgpu", "wgsl"] }
 console_error_panic_hook = "0.1"
-web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document"] }
+web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document", "console"] }
 js-sys = "0.3"
 

--- a/index.html
+++ b/index.html
@@ -5,11 +5,10 @@
     <title>WebGPU with Rust/WASM</title>
     <style>
         body { margin: 0; overflow: hidden; }
-        #camera, #gpu-canvas { position: absolute; top: 0; left: 0; }
+        #gpu-canvas { position: absolute; top: 0; left: 0; }
     </style>
 </head>
 <body>
-    <video id="camera" width="640" height="480" autoplay playsinline></video>
     <canvas id="gpu-canvas" width="640" height="480"></canvas>
     <script type="module">
         // Patch outdated WebGPU limit name for newer Chrome versions.
@@ -23,11 +22,6 @@
             }
             return origRequestDevice.call(this, desc);
         };
-
-        navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
-            const video = document.getElementById('camera');
-            video.srcObject = stream;
-        }).catch(console.error);
 
         import init from './pkg/webgpu_wasm.js';
         init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ impl State {
 #[cfg(target_arch = "wasm32")]
 pub async fn start() -> Result<(), JsValue> {
     console_error_panic_hook::set_once();
+    web_sys::console::log_1(&"Test 321".into());
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
     let canvas = document


### PR DESCRIPTION
## Summary
- remove camera video element and camera permission request
- add console logging from Rust
- enable `console` feature in `web-sys`

## Testing
- `cargo build --target wasm32-unknown-unknown --release --offline -vv > /tmp/build.log 2>&1 && tail -n 20 /tmp/build.log`
- `cargo test --offline > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`