### PR TITLE
Add rotating cube example

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -78,3 +78,31 @@ pub fn perspective(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 
         [0.0, 0.0, znear * zfar * nf, 0.0],
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotation_z_pi() {
+        let r = rotation_z(std::f32::consts::PI);
+        let expected = [
+            [-1.0, 0.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((r[i][j] - expected[i][j]).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn perspective_identity_aspect_one() {
+        let m = perspective(1.0, std::f32::consts::FRAC_PI_2, 0.1, 10.0);
+        assert!((m[0][0] - 1.0).abs() < 0.0001);
+        assert!((m[1][1] - 1.0).abs() < 0.0001);
+    }
+}

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -5,21 +5,24 @@ struct Uniforms {
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
 struct VertexInput {
-    @location(0) position: vec2<f32>,
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec3<f32>,
 };
 
 struct VertexOutput {
     @builtin(position) pos: vec4<f32>,
+    @location(0) color: vec3<f32>,
 };
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.pos = uniforms.mvp * vec4<f32>(input.position, 0.0, 1.0);
+    out.pos = uniforms.mvp * vec4<f32>(input.position, 1.0);
+    out.color = input.color;
     return out;
 }
 
 @fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(input.color, 1.0);
 }


### PR DESCRIPTION
## Summary
- render a barebone 3D krychli misto trojuhelniku
- kazda strana ma jinou barvu a krychle se otaci
- shader podporuje barvy a 3D vrcholy
- pridane jednoduche testy pro matice i data kostky

## Testing
- `RUSTUP_TOOLCHAIN=stable-offline cargo test --offline --target x86_64-unknown-linux-gnu`