### PR TITLE
Upravena orientace front_face

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ impl State {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
+                front_face: wgpu::FrontFace::Cw,
                 ..Default::default()
             },
             depth_stencil: None,


### PR DESCRIPTION
## Shrnutí
- v `PrimitiveState` je nyní nastaveno `front_face: wgpu::FrontFace::Cw`

## Testování
- `cargo test` (neproběhlo – chybí přístup na internet)
