### PR TITLE
Fix cube visibility in WebGPU demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
             return origRequestDevice.call(this, desc);
         };
 
+        const canvas = document.getElementById("gpu-canvas");
+        canvas.width  = canvas.clientWidth  || 800;
+        canvas.height = canvas.clientHeight || 600;
+
         import init from './pkg/webgpu_wasm.js';
         init();
     </script>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ impl State {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
+                cull_mode: None,
                 front_face: wgpu::FrontFace::Cw,
                 ..Default::default()
             },
@@ -246,10 +247,10 @@ impl State {
     }
 
     fn update(&mut self, angle: f32) {
-        use crate::math::{look_at, mat4_mul, perspective, rotation_z, transpose};
+        use crate::math::{look_at, mat4_mul, perspective_lh, rotation_z, transpose};
         let model = rotation_z(angle);
         let view = look_at([2.0, 2.0, 2.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]);
-        let proj = perspective(self.aspect, std::f32::consts::FRAC_PI_4, 0.1, 10.0);
+        let proj = perspective_lh(self.aspect, std::f32::consts::FRAC_PI_4, 0.1, 10.0);
         let m = transpose(mat4_mul(proj, mat4_mul(view, model)));
         let uniform = Uniforms { mvp: m };
         self.queue
@@ -273,7 +274,7 @@ impl State {
                     view: &view,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.1, g: 0.1, b: 0.3, a: 1.0 }),
                         store: wgpu::StoreOp::Store,
                     },
                 })],

--- a/src/math.rs
+++ b/src/math.rs
@@ -79,6 +79,18 @@ pub fn perspective(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 
     ]
 }
 
+/// Levostranná perspektivní matice pro WebGPU (z ∈ [0‥1])
+pub fn perspective_lh(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 4] {
+    let f = 1.0 / (fovy * 0.5).tan();
+    let nf = 1.0 / (zfar - znear);
+    [
+        [f / aspect, 0.0, 0.0, 0.0],
+        [0.0, f, 0.0, 0.0],
+        [0.0, 0.0, zfar * nf, 1.0],
+        [0.0, 0.0, -znear * zfar * nf, 0.0],
+    ]
+}
+
 pub fn transpose(m: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
     let mut t = [[0.0; 4]; 4];
     for i in 0..4 {


### PR DESCRIPTION
## Summary
- add a left-handed perspective matrix
- use the new matrix in state update
- disable face culling and use a clearer background
- ensure the canvas has non-zero size

## Testing
- `cargo test --offline --target x86_64-unknown-linux-gnu --quiet`