### PR TITLE
Ovládání kamery a logování matice pohledu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,15 @@ wasm-bindgen-futures = "0.4"
 # z 0.17 -> 0.18  (nejmenší API změny; když zvládneš, klidně 0.20.1)
 wgpu = { version = "0.20.1", features = ["webgpu", "wgsl"] }
 console_error_panic_hook = "0.1"
-web-sys = { version = "0.3", features = ["HtmlCanvasElement", "Window", "Document", "console", "Performance"] }
+web-sys = { version = "0.3", features = [
+    "HtmlCanvasElement",
+    "Window",
+    "Document",
+    "console",
+    "Performance",
+    "EventTarget",
+    "KeyboardEvent",
+    "MouseEvent"
+] }
 js-sys = "0.3"
 


### PR DESCRIPTION
## Změny
- Přidány Web‑sys featury pro klávesnici a myš
- Nové struktury `Input` a `Camera` s metodou `view`
- `State` udržuje kameru a při `update` vypisuje matici pohledu
- `start` registruje posluchače událostí a dle vstupů aktualizuje kameru

## Testy
- `RUSTUP_TOOLCHAIN=stable-offline cargo test --offline --target x86_64-unknown-linux-gnu`
- `RUSTUP_TOOLCHAIN=stable-offline cargo build --target wasm32-unknown-unknown --release --offline`
