### PR TITLE
Rotating triangle with glam

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,46 +39,12 @@ impl Vertex {
 }
 
 const VERTICES: &[Vertex] = &[
-    // front - red
-    Vertex { position: [-0.5, -0.5, 0.5], color: [1.0, 0.0, 0.0] },
-    Vertex { position: [0.5, -0.5, 0.5], color: [1.0, 0.0, 0.0] },
-    Vertex { position: [0.5, 0.5, 0.5], color: [1.0, 0.0, 0.0] },
-    Vertex { position: [-0.5, 0.5, 0.5], color: [1.0, 0.0, 0.0] },
-    // back - green
-    Vertex { position: [0.5, -0.5, -0.5], color: [0.0, 1.0, 0.0] },
-    Vertex { position: [-0.5, -0.5, -0.5], color: [0.0, 1.0, 0.0] },
-    Vertex { position: [-0.5, 0.5, -0.5], color: [0.0, 1.0, 0.0] },
-    Vertex { position: [0.5, 0.5, -0.5], color: [0.0, 1.0, 0.0] },
-    // left - blue
-    Vertex { position: [-0.5, -0.5, -0.5], color: [0.0, 0.0, 1.0] },
-    Vertex { position: [-0.5, -0.5, 0.5], color: [0.0, 0.0, 1.0] },
-    Vertex { position: [-0.5, 0.5, 0.5], color: [0.0, 0.0, 1.0] },
-    Vertex { position: [-0.5, 0.5, -0.5], color: [0.0, 0.0, 1.0] },
-    // right - yellow
-    Vertex { position: [0.5, -0.5, 0.5], color: [1.0, 1.0, 0.0] },
-    Vertex { position: [0.5, -0.5, -0.5], color: [1.0, 1.0, 0.0] },
-    Vertex { position: [0.5, 0.5, -0.5], color: [1.0, 1.0, 0.0] },
-    Vertex { position: [0.5, 0.5, 0.5], color: [1.0, 1.0, 0.0] },
-    // top - cyan
-    Vertex { position: [-0.5, 0.5, 0.5], color: [0.0, 1.0, 1.0] },
-    Vertex { position: [0.5, 0.5, 0.5], color: [0.0, 1.0, 1.0] },
-    Vertex { position: [0.5, 0.5, -0.5], color: [0.0, 1.0, 1.0] },
-    Vertex { position: [-0.5, 0.5, -0.5], color: [0.0, 1.0, 1.0] },
-    // bottom - magenta
-    Vertex { position: [-0.5, -0.5, -0.5], color: [1.0, 0.0, 1.0] },
-    Vertex { position: [0.5, -0.5, -0.5], color: [1.0, 0.0, 1.0] },
-    Vertex { position: [0.5, -0.5, 0.5], color: [1.0, 0.0, 1.0] },
-    Vertex { position: [-0.5, -0.5, 0.5], color: [1.0, 0.0, 1.0] },
+    Vertex { position: [0.0, 0.5, 0.0], color: [1.0, 0.0, 0.0] },
+    Vertex { position: [-0.5, -0.5, 0.0], color: [0.0, 1.0, 0.0] },
+    Vertex { position: [0.5, -0.5, 0.0], color: [0.0, 0.0, 1.0] },
 ];
 
-const INDICES: &[u16] = &[
-    0, 1, 2, 0, 2, 3, // front
-    4, 5, 6, 4, 6, 7, // back
-    8, 9, 10, 8, 10, 11, // left
-    12, 13, 14, 12, 14, 15, // right
-    16, 17, 18, 16, 18, 19, // top
-    20, 21, 22, 20, 22, 23, // bottom
-];
+const INDICES: &[u16] = &[0, 1, 2];
 
 #[cfg(target_arch = "wasm32")]
 fn as_bytes<T: Copy>(data: &[T]) -> &[u8] {
@@ -343,12 +309,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cube_vertex_count() {
-        assert_eq!(VERTICES.len(), 24);
+    fn triangle_vertex_count() {
+        assert_eq!(VERTICES.len(), 3);
     }
 
     #[test]
-    fn cube_index_count() {
-        assert_eq!(INDICES.len(), 36);
+    fn triangle_index_count() {
+        assert_eq!(INDICES.len(), 3);
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,104 +1,36 @@
+use glam::{Mat4, Vec3};
+
 pub fn mat4_mul(a: [[f32; 4]; 4], b: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
-    let mut r = [[0.0; 4]; 4];
-    for i in 0..4 {
-        for j in 0..4 {
-            r[i][j] = a[i][0] * b[0][j] + a[i][1] * b[1][j] + a[i][2] * b[2][j] + a[i][3] * b[3][j];
-        }
-    }
-    r
+    (Mat4::from_cols_array_2d(&a) * Mat4::from_cols_array_2d(&b)).to_cols_array_2d()
 }
 
 pub fn rotation_y(angle: f32) -> [[f32; 4]; 4] {
-    let c = angle.cos();
-    let s = angle.sin();
-    [
-        [c, 0.0, s, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [-s, 0.0, c, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ]
+    Mat4::from_rotation_y(angle).to_cols_array_2d()
 }
 
 pub fn rotation_z(angle: f32) -> [[f32; 4]; 4] {
-    let c = angle.cos();
-    let s = angle.sin();
-    [
-        [c, -s, 0.0, 0.0],
-        [s, c, 0.0, 0.0],
-        [0.0, 0.0, 1.0, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ]
+    Mat4::from_rotation_z(angle).to_cols_array_2d()
 }
 
 pub fn translation(tx: f32, ty: f32, tz: f32) -> [[f32; 4]; 4] {
-    [
-        [1.0, 0.0, 0.0, tx],
-        [0.0, 1.0, 0.0, ty],
-        [0.0, 0.0, 1.0, tz],
-        [0.0, 0.0, 0.0, 1.0],
-    ]
-}
-
-fn normalize(v: [f32; 3]) -> [f32; 3] {
-    let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
-    [v[0] / l, v[1] / l, v[2] / l]
-}
-
-fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
-    [
-        a[1] * b[2] - a[2] * b[1],
-        a[2] * b[0] - a[0] * b[2],
-        a[0] * b[1] - a[1] * b[0],
-    ]
-}
-
-fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
-    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+    Mat4::from_translation(Vec3::new(tx, ty, tz)).to_cols_array_2d()
 }
 
 pub fn look_at(eye: [f32; 3], center: [f32; 3], up: [f32; 3]) -> [[f32; 4]; 4] {
-    let f = normalize([center[0] - eye[0], center[1] - eye[1], center[2] - eye[2]]);
-    let s = normalize(cross(f, up));
-    let u = cross(s, f);
-    [
-        [s[0], u[0], -f[0], 0.0],
-        [s[1], u[1], -f[1], 0.0],
-        [s[2], u[2], -f[2], 0.0],
-        [-dot(s, eye), -dot(u, eye), dot(f, eye), 1.0],
-    ]
+    Mat4::look_at_lh(Vec3::from(eye), Vec3::from(center), Vec3::from(up)).to_cols_array_2d()
 }
 
 pub fn perspective(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 4] {
-    let f = 1.0 / (fovy / 2.0).tan();
-    let nf = 1.0 / (znear - zfar);
-    [
-        [f / aspect, 0.0, 0.0, 0.0],
-        [0.0, f, 0.0, 0.0],
-        [0.0, 0.0, zfar * nf, -1.0],
-        [0.0, 0.0, znear * zfar * nf, 0.0],
-    ]
+    Mat4::perspective_lh(fovy, aspect, znear, zfar).to_cols_array_2d()
 }
 
 /// Levostranná perspektivní matice pro WebGPU (z ∈ [0‥1])
 pub fn perspective_lh(aspect: f32, fovy: f32, znear: f32, zfar: f32) -> [[f32; 4]; 4] {
-    let f = 1.0 / (fovy * 0.5).tan();
-    let nf = 1.0 / (zfar - znear);
-    [
-        [f / aspect, 0.0, 0.0, 0.0],
-        [0.0, f, 0.0, 0.0],
-        [0.0, 0.0, zfar * nf, 1.0],
-        [0.0, 0.0, -znear * zfar * nf, 0.0],
-    ]
+    Mat4::perspective_lh(fovy, aspect, znear, zfar).to_cols_array_2d()
 }
 
 pub fn transpose(m: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
-    let mut t = [[0.0; 4]; 4];
-    for i in 0..4 {
-        for j in 0..4 {
-            t[i][j] = m[j][i];
-        }
-    }
-    t
+    Mat4::from_cols_array_2d(&m).transpose().to_cols_array_2d()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- use `glam` for matrix operations
- render simple triangle and rotate it
- update tests for triangle

## Testing
- `RUSTUP_TOOLCHAIN=stable RUSTUP_OFFLINE=1 cargo test --offline --target x86_64-unknown-linux-gnu --quiet`