### PR TITLE
Implement Phong shading with dynamic lights

### DIFF
--- a/src/render/data.rs
+++ b/src/render/data.rs
@@ -1,12 +1,13 @@
 #![cfg(target_arch = "wasm32")]
 
 use wgpu::VertexBufferLayout;
-
+use glam::Vec3;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct Vertex {
     pub position: [f32; 3],
     pub color: [f32; 3],
+    pub normal: [f32; 3],
 }
 
 impl Vertex {
@@ -26,6 +27,11 @@ impl Vertex {
                     shader_location: 1,
                     format: wgpu::VertexFormat::Float32x3,
                 },
+                wgpu::VertexAttribute {
+                    offset: (mem::size_of::<[f32; 3]>() * 2) as wgpu::BufferAddress,
+                    shader_location: 2,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
             ],
         }
     }
@@ -36,103 +42,127 @@ pub const VERTICES: &[Vertex] = &[
     Vertex {
         position: [-0.5, -0.5, 0.5],
         color: [1.0, 0.0, 0.0],
+        normal: [0.0, 0.0, 1.0],
     },
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [1.0, 0.0, 0.0],
+        normal: [0.0, 0.0, 1.0],
     },
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [1.0, 0.0, 0.0],
+        normal: [0.0, 0.0, 1.0],
     },
     Vertex {
         position: [-0.5, 0.5, 0.5],
         color: [1.0, 0.0, 0.0],
+        normal: [0.0, 0.0, 1.0],
     },
     // back - green
     Vertex {
         position: [0.5, -0.5, -0.5],
         color: [0.0, 1.0, 0.0],
+        normal: [0.0, 0.0, -1.0],
     },
     Vertex {
         position: [-0.5, -0.5, -0.5],
         color: [0.0, 1.0, 0.0],
+        normal: [0.0, 0.0, -1.0],
     },
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [0.0, 1.0, 0.0],
+        normal: [0.0, 0.0, -1.0],
     },
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [0.0, 1.0, 0.0],
+        normal: [0.0, 0.0, -1.0],
     },
     // left - blue
     Vertex {
         position: [-0.5, -0.5, -0.5],
         color: [0.0, 0.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
     },
     Vertex {
         position: [-0.5, -0.5, 0.5],
         color: [0.0, 0.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
     },
     Vertex {
         position: [-0.5, 0.5, 0.5],
         color: [0.0, 0.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
     },
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [0.0, 0.0, 1.0],
+        normal: [-1.0, 0.0, 0.0],
     },
     // right - yellow
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [1.0, 1.0, 0.0],
+        normal: [1.0, 0.0, 0.0],
     },
     Vertex {
         position: [0.5, -0.5, -0.5],
         color: [1.0, 1.0, 0.0],
+        normal: [1.0, 0.0, 0.0],
     },
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [1.0, 1.0, 0.0],
+        normal: [1.0, 0.0, 0.0],
     },
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [1.0, 1.0, 0.0],
+        normal: [1.0, 0.0, 0.0],
     },
     // top - cyan
     Vertex {
         position: [-0.5, 0.5, 0.5],
         color: [0.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
     },
     Vertex {
         position: [0.5, 0.5, 0.5],
         color: [0.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
     },
     Vertex {
         position: [0.5, 0.5, -0.5],
         color: [0.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
     },
     Vertex {
         position: [-0.5, 0.5, -0.5],
         color: [0.0, 1.0, 1.0],
+        normal: [0.0, 1.0, 0.0],
     },
     // bottom - magenta
     Vertex {
         position: [-0.5, -0.5, -0.5],
         color: [1.0, 0.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
     },
     Vertex {
         position: [0.5, -0.5, -0.5],
         color: [1.0, 0.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
     },
     Vertex {
         position: [0.5, -0.5, 0.5],
         color: [1.0, 0.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
     },
     Vertex {
         position: [-0.5, -0.5, 0.5],
         color: [1.0, 0.0, 1.0],
+        normal: [0.0, -1.0, 0.0],
     },
 ];
 
@@ -156,6 +186,17 @@ pub fn as_bytes<T: Copy>(data: &[T]) -> &[u8] {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct Uniforms {
+pub struct Light {
+    pub position: Vec3,
+    pub color: Vec3,
+    pub _pad: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SceneUniforms {
     pub mvp: [[f32; 4]; 4],
+    pub camera_pos: [f32; 3],
+    pub _pad0: f32,
+    pub lights: [Light; 2],
 }

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
 use wgpu::util::DeviceExt;
 
-use crate::render::data::{self, Uniforms};
+use crate::render::data::{self, SceneUniforms, Light};
 use crate::render::{depth, pipeline};
 
 pub struct State {
@@ -83,7 +83,7 @@ impl State {
             label: Some("bind group layout"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,
@@ -95,12 +95,26 @@ impl State {
 
         let pipeline = pipeline::build(&device, config.format, &bind_group_layout);
 
-        let uniform = Uniforms {
+        let uniform = SceneUniforms {
             mvp: [
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
+            ],
+            camera_pos: [0.0, 0.0, 0.0],
+            _pad0: 0.0,
+            lights: [
+                Light {
+                    position: glam::Vec3::new(1.5, 1.0, 2.0),
+                    color: glam::Vec3::new(1.0, 1.0, 1.0),
+                    _pad: 0.0,
+                },
+                Light {
+                    position: glam::Vec3::new(-1.5, 1.0, -2.0),
+                    color: glam::Vec3::new(1.0, 0.0, 0.0),
+                    _pad: 0.0,
+                },
             ],
         };
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -133,9 +147,23 @@ impl State {
         })
     }
 
-    pub fn update(&self, mvp: Mat4) {
-        let uniform = Uniforms {
+    pub fn update(&self, mvp: Mat4, camera_pos: glam::Vec3) {
+        let uniform = SceneUniforms {
             mvp: mvp.to_cols_array_2d(),
+            camera_pos: camera_pos.into(),
+            _pad0: 0.0,
+            lights: [
+                Light {
+                    position: glam::Vec3::new(1.5, 1.0, 2.0),
+                    color: glam::Vec3::new(1.0, 1.0, 1.0),
+                    _pad: 0.0,
+                },
+                Light {
+                    position: glam::Vec3::new(-1.5, 1.0, -2.0),
+                    color: glam::Vec3::new(1.0, 0.0, 0.0),
+                    _pad: 0.0,
+                },
+            ],
         };
         self.queue
             .write_buffer(&self.uniform_buffer, 0, data::as_bytes(&[uniform]));

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,28 +1,58 @@
-struct Uniforms {
-    mvp: mat4x4<f32>,
+struct Light {
+    position: vec3<f32>,
+    color: vec3<f32>,
+    _pad: f32,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+struct SceneUniforms {
+    mvp: mat4x4<f32>,
+    camera_pos: vec3<f32>,
+    _pad0: f32,
+    lights: array<Light, 2>,
+};
+
+@group(0) @binding(0) var<uniform> scene: SceneUniforms;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec3<f32>,
+    @location(2) normal: vec3<f32>,
 };
 
 struct VertexOutput {
     @builtin(position) pos: vec4<f32>,
     @location(0) color: vec3<f32>,
+    @location(1) world_pos: vec3<f32>,
+    @location(2) world_normal: vec3<f32>,
 };
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.pos = uniforms.mvp * vec4<f32>(input.position, 1.0);
+    out.pos = scene.mvp * vec4<f32>(input.position, 1.0);
     out.color = input.color;
+    out.world_pos = input.position;
+    out.world_normal = input.normal;
     return out;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(input.color, 1.0);
+    let normal = normalize(input.world_normal);
+    let view_dir = normalize(scene.camera_pos - input.world_pos);
+    var result = input.color * 0.1; // ambient
+
+    // light 0
+    let l0_dir = normalize(scene.lights[0].position - input.world_pos);
+    let diff0 = max(dot(normal, l0_dir), 0.0);
+    let spec0 = pow(max(dot(normal, normalize(l0_dir + view_dir)), 0.0), 32.0);
+    result += (diff0 * input.color + spec0) * scene.lights[0].color;
+
+    // light 1
+    let l1_dir = normalize(scene.lights[1].position - input.world_pos);
+    let diff1 = max(dot(normal, l1_dir), 0.0);
+    let spec1 = pow(max(dot(normal, normalize(l1_dir + view_dir)), 0.0), 32.0);
+    result += (diff1 * input.color + spec1) * scene.lights[1].color;
+
+    return vec4<f32>(result, 1.0);
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -47,11 +47,12 @@ pub async fn start() -> Result<(), JsValue> {
         {
             let mut cam = camera_c.borrow_mut();
             cam.update(dt);
+            let cam_pos = cam.position;
             let cam_matrix = cam.matrix();
             let model = Mat4::from_rotation_z(angle);
             let mvp = cam_matrix * model;
             let mut st = state_c.borrow_mut();
-            st.update(mvp);
+            st.update(mvp, cam_pos);
             if st.render().is_err() {
                 return;
             }


### PR DESCRIPTION
## Summary
- extend vertex data with normals
- add `Light` and `SceneUniforms` structs
- create uniform buffer for camera and two lights
- pass camera position and lights to shader
- implement Phong shading in WGSL shader

## Testing
- `cargo check --target wasm32-unknown-unknown --offline`
- `cargo build --target wasm32-unknown-unknown --release --offline`


------
https://chatgpt.com/codex/tasks/task_b_683b3e9e73388331a8ad7330f4b835e6