### PR TITLE
Fix surface creation lifetime

### DIFF
--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -9,6 +9,7 @@ use crate::render::data::{self, SceneUniforms, Light};
 use crate::render::{depth, pipeline};
 
 pub struct State {
+    instance: wgpu::Instance,
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -134,6 +135,7 @@ impl State {
         });
 
         Ok(Self {
+            instance,
             surface,
             device,
             queue,


### PR DESCRIPTION
## Summary
- hold `wgpu::Instance` inside `State`
- keep the surface alive on Windows

## Testing
- `RUSTUP_TOOLCHAIN=stable-offline cargo test --offline --target x86_64-unknown-linux-gnu`
- `RUSTUP_TOOLCHAIN=stable-offline cargo build --target wasm32-unknown-unknown --release --offline`


------
https://chatgpt.com/codex/tasks/task_b_683b55bb4f148331bb08c996fc255031