### PR TITLE
Fix surface creation lifetime

### DIFF
--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -9,7 +9,9 @@ use crate::render::data::{self, SceneUniforms, Light};
 use crate::render::{depth, pipeline};
 
 pub struct State {
+    instance: wgpu::Instance,
     surface: wgpu::Surface<'static>,
+    canvas: HtmlCanvasElement,
     device: wgpu::Device,
     queue: wgpu::Queue,
     pipeline: wgpu::RenderPipeline,
@@ -26,11 +28,10 @@ pub struct State {
 impl State {
     pub async fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsValue> {
         let instance = wgpu::Instance::default();
+        let canvas = canvas.clone();
         let surface = instance
-            .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+            .create_surface(&canvas)
             .map_err(|e| JsValue::from_str(&format!("{e:?}")))?;
-        let surface =
-            unsafe { std::mem::transmute::<wgpu::Surface<'_>, wgpu::Surface<'static>>(surface) };
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -134,7 +135,9 @@ impl State {
         });
 
         Ok(Self {
+            instance,
             surface,
+            canvas,
             device,
             queue,
             pipeline,


### PR DESCRIPTION
## Summary
- keep the canvas alive in `State`
- drop the transmute when creating the surface

## Testing
- `RUSTUP_TOOLCHAIN=stable cargo test --offline --target x86_64-unknown-linux-gnu`
- `RUSTUP_TOOLCHAIN=stable cargo build --target wasm32-unknown-unknown --release --offline` *(fails: `can't find crate for core`)*

------
https://chatgpt.com/codex/tasks/task_b_683b55bb4f148331bb08c996fc255031