### PR TITLE
Fix surface creation lifetime

### DIFF
--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -9,6 +9,7 @@ use crate::render::data::{self, SceneUniforms, Light};
 use crate::render::{depth, pipeline};
 
 pub struct State {
+    instance: wgpu::Instance,
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -25,7 +26,12 @@ pub struct State {
 
 impl State {
     pub async fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsValue> {
+        // Surfaces keep a reference to the `Instance`.  If the instance gets
+        // dropped, rendering may fail on some platforms (notably Windows).
         let instance = wgpu::Instance::default();
+
+        // `HtmlCanvasElement` itself doesn't implement `Into<SurfaceTarget>`,
+        // so use the explicit `Canvas` variant when creating the surface.
         let surface = instance
             .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
             .map_err(|e| JsValue::from_str(&format!("{e:?}")))?;
@@ -134,6 +140,7 @@ impl State {
         });
 
         Ok(Self {
+            instance,
             surface,
             device,
             queue,


### PR DESCRIPTION
## Summary
- hold `wgpu::Instance` inside `State`
- document why `Instance` must be kept alive and clarify surface creation on web

## Testing
- `RUSTUP_HOME=$PWD/.rustup CARGO_HOME=$PWD/.cargo RUSTUP_TOOLCHAIN=stable-offline RUSTUP_OFFLINE=1 ~/.cargo/bin/cargo test --offline --target x86_64-unknown-linux-gnu`
- `RUSTUP_HOME=$PWD/.rustup CARGO_HOME=$PWD/.cargo RUSTUP_TOOLCHAIN=stable-offline RUSTUP_OFFLINE=1 ~/.cargo/bin/cargo build --target wasm32-unknown-unknown --release --offline`


------
https://chatgpt.com/codex/tasks/task_b_683b55bb4f148331bb08c996fc255031