### PR TITLE
Fix cube visibility on Windows

### DIFF
--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -31,7 +31,7 @@ pub fn build(device: &Device, format: TextureFormat, layout: &BindGroupLayout) -
         }),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
-            cull_mode: Some(wgpu::Face::Front),
+            cull_mode: Some(wgpu::Face::Back),
             front_face: wgpu::FrontFace::Ccw,
             ..Default::default()
         },


### PR DESCRIPTION
## Summary
- fix culling settings for the render pipeline

## Testing
- `RUSTUP_TOOLCHAIN=stable-offline cargo check --offline`

------
https://chatgpt.com/codex/tasks/task_b_683b65c2b058833182693313155dfc3b