### PR TITLE
Fix lighting with world transforms

### DIFF
--- a/src/render/data.rs
+++ b/src/render/data.rs
@@ -196,6 +196,9 @@ pub struct Light {
 #[derive(Clone, Copy)]
 pub struct SceneUniforms {
     pub mvp: [[f32; 4]; 4],
+    pub model: [[f32; 4]; 4],
+    /// Normal matrix padded to vec4 rows so that the layout matches WGSL
+    pub normal_matrix: [[f32; 4]; 3],
     pub camera_pos: [f32; 3],
     pub _pad0: f32,
     pub lights: [Light; 2],

--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -31,7 +31,7 @@ pub fn build(device: &Device, format: TextureFormat, layout: &BindGroupLayout) -
         }),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
-            cull_mode: Some(wgpu::Face::Front),
+            cull_mode: Some(wgpu::Face::Back),
             front_face: wgpu::FrontFace::Ccw,
             ..Default::default()
         },

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -1,6 +1,6 @@
 #![cfg(target_arch = "wasm32")]
 
-use glam::Mat4;
+use glam::{Mat4, Mat3};
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
 use wgpu::util::DeviceExt;
@@ -102,6 +102,17 @@ impl State {
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
             ],
+            model: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            normal_matrix: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
             camera_pos: [0.0, 0.0, 0.0],
             _pad0: 0.0,
             lights: [
@@ -149,9 +160,15 @@ impl State {
         })
     }
 
-    pub fn update(&self, mvp: Mat4, camera_pos: glam::Vec3) {
+    pub fn update(&self, mvp: Mat4, model: Mat4, normal_matrix: Mat3, camera_pos: glam::Vec3) {
         let uniform = SceneUniforms {
             mvp: mvp.to_cols_array_2d(),
+            model: model.to_cols_array_2d(),
+            normal_matrix: [
+                [normal_matrix.x_axis.x, normal_matrix.x_axis.y, normal_matrix.x_axis.z, 0.0],
+                [normal_matrix.y_axis.x, normal_matrix.y_axis.y, normal_matrix.y_axis.z, 0.0],
+                [normal_matrix.z_axis.x, normal_matrix.z_axis.y, normal_matrix.z_axis.z, 0.0],
+            ],
             camera_pos: camera_pos.into(),
             _pad0: 0.0,
             lights: [

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -7,6 +7,8 @@ struct Light {
 
 struct SceneUniforms {
     mvp: mat4x4<f32>,
+    model: mat4x4<f32>,
+    normal_matrix: mat3x3<f32>,
     camera_pos: vec3<f32>,
     _pad0: f32,
     lights: array<Light, 2>,
@@ -31,9 +33,9 @@ struct VertexOutput {
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
     out.pos = scene.mvp * vec4<f32>(input.position, 1.0);
+    out.world_pos = (scene.model * vec4<f32>(input.position, 1.0)).xyz;
+    out.world_normal = normalize(scene.normal_matrix * input.normal);
     out.color = input.color;
-    out.world_pos = input.position;
-    out.world_normal = input.normal;
     return out;
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, rc::Rc};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{closure::Closure, JsCast};
 
-use glam::Mat4;
+use glam::{Mat4, Mat3};
 
 use crate::input::camera::Camera;
 use crate::input::{keyboard, mouse};
@@ -50,9 +50,10 @@ pub async fn start() -> Result<(), JsValue> {
             let cam_pos = cam.position;
             let cam_matrix = cam.matrix();
             let model = Mat4::from_rotation_z(angle);
+            let normal_matrix = Mat3::from_mat4(model).inverse().transpose();
             let mvp = cam_matrix * model;
             let mut st = state_c.borrow_mut();
-            st.update(mvp, cam_pos);
+            st.update(mvp, model, normal_matrix, cam_pos);
             if st.render().is_err() {
                 return;
             }


### PR DESCRIPTION
## Summary
- update `SceneUniforms` to hold model and normal matrices
- compute and upload world transforms
- use world position and normal in shader
- use back-face culling for nicer specular highlights

## Testing
- `bash ci_offline_setup.sh` *(fails: not a directory)*
- `cargo test --offline --target x86_64-unknown-linux-gnu` *(fails: could not download file)*
- `cargo check --offline --target wasm32-unknown-unknown` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_b_683dba968544833191b530b3b32d4b18