### PR TITLE
Add fullscreen resize handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
     <title>WebGPU with Rust/WASM</title>
     <style>
         body { margin: 0; overflow: hidden; }
-        #gpu-canvas { position: absolute; top: 0; left: 0; }
+        #gpu-canvas { position: absolute; top: 0; left: 0; width: 100vw; height: 100vh; }
     </style>
 </head>
 <body>
     <button id="orbit-btn" style="position:absolute;top:10px;left:10px;z-index:1;">Orbit</button>
     <button id="free-btn" style="position:absolute;top:40px;left:10px;z-index:1;">Free</button>
     <button id="grid-btn" style="position:absolute;top:70px;left:10px;z-index:1;">Hide Grid</button>
-    <canvas id="gpu-canvas" width="640" height="480"></canvas>
+    <canvas id="gpu-canvas"></canvas>
     <script type="module">
         // Patch outdated WebGPU limit name for newer Chrome versions.
         const origRequestDevice = GPUAdapter.prototype.requestDevice;
@@ -27,12 +27,13 @@
         };
 
         const canvas = document.getElementById("gpu-canvas");
-        canvas.width  = canvas.clientWidth  || 800;
-        canvas.height = canvas.clientHeight || 600;
+        canvas.width  = window.innerWidth;
+        canvas.height = window.innerHeight;
         let grid = true;
 
-        import init, { set_camera_mode, set_grid_visible } from './pkg/webgpu_wasm.js';
+        import init, { set_camera_mode, set_grid_visible, resize } from './pkg/webgpu_wasm.js';
         await init();
+        resize(canvas.width, canvas.height);
         set_grid_visible(true);
         document.getElementById("grid-btn").onclick = () => {
             grid = !grid;
@@ -42,6 +43,12 @@
 
         document.getElementById('orbit-btn').onclick = () => set_camera_mode('orbit');
         document.getElementById('free-btn').onclick = () => set_camera_mode('free');
+
+        window.addEventListener('resize', () => {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+            resize(canvas.width, canvas.height);
+        });
     </script>
 </body>
 </html>

--- a/src/input/active_camera.rs
+++ b/src/input/active_camera.rs
@@ -27,6 +27,11 @@ impl ActiveCamera {
         self.active = ty;
     }
 
+    pub fn set_aspect(&mut self, aspect: f32) {
+        self.free.set_aspect(aspect);
+        self.orbit.set_aspect(aspect);
+    }
+
     fn active_mut(&mut self) -> &mut dyn CameraController {
         match self.active {
             CameraType::Free => &mut self.free,

--- a/src/input/camera.rs
+++ b/src/input/camera.rs
@@ -34,6 +34,10 @@ impl Camera {
         }
     }
 
+    pub fn set_aspect(&mut self, aspect: f32) {
+        self.aspect = aspect;
+    }
+
     pub fn key_down(&mut self, code: String) {
         self.pressed.insert(code);
     }

--- a/src/input/orbit_camera.rs
+++ b/src/input/orbit_camera.rs
@@ -34,6 +34,10 @@ impl OrbitCamera {
         }
     }
 
+    pub fn set_aspect(&mut self, aspect: f32) {
+        self.aspect = aspect;
+    }
+
     pub fn key_down(&mut self, code: String) {
         self.pressed.insert(code);
     }

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -18,6 +18,7 @@ pub struct State {
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
     queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
@@ -187,6 +188,7 @@ impl State {
             surface,
             device,
             queue,
+            config,
             pipeline,
             vertex_buffer,
             index_buffer,
@@ -202,6 +204,20 @@ impl State {
     }
     pub fn set_grid_visible(&mut self, show: bool) {
         self.draw_grid = show;
+    }
+
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.config.width = width;
+        self.config.height = height;
+        self.aspect = width as f32 / height as f32;
+        self.surface.configure(&self.device, &self.config);
+        let (depth_texture, depth_view) =
+            depth::create(&self.device, width, height, self.depth_format);
+        self.depth_texture = depth_texture;
+        self.depth_view = depth_view;
     }
 
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -39,6 +39,20 @@ pub fn set_camera_mode(mode: &str) {
     });
 }
 
+#[wasm_bindgen]
+pub fn resize(width: u32, height: u32) {
+    STATE.with(|s| {
+        if let Some(st) = &*s.borrow() {
+            st.borrow_mut().resize(width, height);
+        }
+    });
+    CAMERA.with(|c| {
+        if let Some(cam) = &*c.borrow() {
+            cam.borrow_mut().set_aspect(width as f32 / height as f32);
+        }
+    });
+}
+
 #[wasm_bindgen(start)]
 pub async fn start() -> Result<(), JsValue> {
     console_error_panic_hook::set_once();


### PR DESCRIPTION
## Summary
- make canvas stretch across the window
- call into WASM to resize surface and cameras
- handle window resize in JS

## Testing
- `cargo check`
- `RUSTFLAGS=--cfg=web_sys_unstable_apis wasm-pack build --target web` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_b_684493780a0c8331b2bd72378abbfb61