### PR TITLE
Update AGENTS for online build workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,7 @@
 Before committing or pushing changes to this repository:
 
-1. Spusťte `./ci_offline_setup.sh`, který rozbalí `vendor/`, nastaví `RUSTUP_TOOLCHAIN=stable-offline` a spustí `cargo test --offline`. Testy musí projít.
-2. Poté spusťte `scripts/pre-push` pro aktualizaci `all_sources.txt`.
+1. Run `cargo test` and ensure all tests pass.
+2. Then run `scripts/pre-push` to update `all_sources.txt`.
 
-Offline builds are supported. Use `./offline.sh pack-all` to archive the vendor
-directory and toolchain caches in one step. Run `./offline.sh unpack-all` or
-`./ci_offline_setup.sh` to restore everything and run the tests.
+If needed you can run `./offline.sh pack-all` to build offline archives. Use `./offline.sh unpack-all` to restore them.
 See the README for full instructions.


### PR DESCRIPTION
## Summary
- update `AGENTS.md` to drop offline setup requirement and instruct running `cargo test`

## Testing
- `./ci_offline_setup.sh`
- `scripts/pre-push`


------
https://chatgpt.com/codex/tasks/task_b_68656eb5a2a083318f236ebbaec28181